### PR TITLE
BF: Quote the column name of the Insert from the temp table into the target table

### DIFF
--- a/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6/DbContextExtensions.cs
+++ b/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6/DbContextExtensions.cs
@@ -1281,7 +1281,7 @@ namespace Tanneryd.BulkOperations.EF6
                             response.TablesWithNoCheckConstraints.Add(tableName.Fullname);
                         }
 
-                        var columnNames = string.Join(",", nonPrimaryKeyColumnMappings.Select(p => p.TableColumn.Name));
+                        var columnNames = string.Join(",", nonPrimaryKeyColumnMappings.Select(p => $"[{p.TableColumn.Name}]"));
                         query = $@"                                  
                                 INSERT INTO {tableName.Fullname} ({columnNames})
                                 SELECT {columnNames}


### PR DESCRIPTION
Hi there, I ran into some issues when using this since I'm using some not ideal column names for a table that is used to hold integration data. To be more specific I have a column named "Key", which is a SQL keyword. As said earlier I only chose that name because the provider uses the same name for their column in another database.
 
This basically prevents the SQL-interpreter from reading the column name as a keyword.
 
For posterity here is the exception that I got:

> System.Data.SqlClient.SqlException: 'Incorrect syntax near the keyword 'Key'.
> Incorrect syntax near the keyword 'Key'.'

![charactersynchronization_ debugging _-_microsoft_v_2018-08-11_03-49-58](https://user-images.githubusercontent.com/5727793/43986941-d756d72c-9d19-11e8-9bfe-9a1673ba1263.png)

And that is because my table-class looks like this:

![charactersynchronization_-_microsoft_visual_studio_2018-08-11_03-52-09](https://user-images.githubusercontent.com/5727793/43986958-fd8db848-9d19-11e8-958d-b845ad741e48.png)

I realize that it is possible that you intended that the developer should solve this by providing their own column mapping via an attribute?

p.s. I see that you fixed some garbage collection issues, please make a release package for them. Thank you.