### PR TITLE
fix for issue #23 (BulkSelectNotExisting)

### DIFF
--- a/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6.Tests/Models/DM/Invoice/Invoice.cs
+++ b/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6.Tests/Models/DM/Invoice/Invoice.cs
@@ -1,0 +1,71 @@
+﻿/*
+* Copyright ©  2017-2019 Tånneryd IT AB
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* 
+*   http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+using System;
+using System.Collections.Generic;
+
+namespace Tanneryd.BulkOperations.EF6.Tests.DM.Invoice
+{
+    public class Invoice
+    {
+        public Invoice()
+        {
+            BatchInvoices = new HashSet<BatchInvoiceItem>();
+            Journals = new HashSet<InvoiceItem>();
+        }
+        public Guid Id { get; set; }
+        public ICollection<BatchInvoiceItem> BatchInvoices { get; set; }
+        public ICollection<InvoiceItem> Journals { get; set; }
+    }
+
+    public class Journal
+    {
+        public Journal()
+        {
+            Invoices= new HashSet<InvoiceItem>();
+        }
+
+        public Guid Id { get; set; }
+        public ICollection<InvoiceItem> Invoices { get; set; }
+    }
+
+    public class BatchInvoice
+    {
+        public BatchInvoice()
+        {
+            Invoices = new HashSet<BatchInvoiceItem>();
+        }
+        public Guid Id { get; set; }
+        public ICollection<BatchInvoiceItem> Invoices { get; set; }
+    }
+
+    public class BatchInvoiceItem
+    {
+        public Guid Id { get; set; }
+        public Guid BatchInvoiceId { get; set; }
+        public BatchInvoice BatchInvoice { get; set; }
+        public Guid InvoiceId { get; set; }
+        public Invoice Invoice { get; set; }
+    }
+
+    public class InvoiceItem
+    {
+        public int Id { get; set; }
+        public Guid JournalId { get; set; }
+        public Journal Journal { get; set; }
+        public Guid InvoiceId { get; set; }
+        public Invoice Invoice { get; set; }
+    }
+}

--- a/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6.Tests/Models/EF/InvoiceContext.cs
+++ b/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6.Tests/Models/EF/InvoiceContext.cs
@@ -1,0 +1,92 @@
+﻿/*
+ * Copyright ©  2017-2019 Tånneryd IT AB
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity;
+using Tanneryd.BulkOperations.EF6.Tests.DM.Invoice;
+
+namespace Tanneryd.BulkOperations.EF6.Tests.EF
+{
+
+
+    public class InvoiceContext : DbContext
+    {
+        public DbSet<Invoice> Invoices { get; set; }
+        public DbSet<Journal> Journals { get; set; }
+        public DbSet<BatchInvoice> BatchInvoices { get; set; }
+        public DbSet<InvoiceItem> InvoiceItems { get; set; }
+        public DbSet<BatchInvoiceItem> BatchInvoiceItems { get; set; }
+
+        protected override void OnModelCreating(DbModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<BatchInvoiceItem>()
+                .ToTable("BatchInvoiceItem")
+                .HasKey(p => p.Id);
+            modelBuilder.Entity<BatchInvoiceItem>()
+                .Property(p => p.Id)
+                .HasColumnName("PrimaryKey");
+
+            modelBuilder.Entity<InvoiceItem>()
+                .ToTable("InvoiceItem")
+                .HasKey(p => p.Id);
+            modelBuilder.Entity<InvoiceItem>()
+                .Property(p => p.Id)
+                .HasColumnName("PrimaryKey");
+            modelBuilder.Entity<InvoiceItem>()
+                .Property(p => p.Id)
+                .HasDatabaseGeneratedOption(DatabaseGeneratedOption.Identity);
+
+            modelBuilder.Entity<Invoice>()
+                .ToTable("Invoice")
+                .HasKey(p => p.Id);
+            modelBuilder.Entity<Invoice>()
+                .Property(p => p.Id)
+                .HasColumnName("PrimaryKey");
+            modelBuilder.Entity<Invoice>()
+                .HasMany(b => b.BatchInvoices)
+                .WithRequired(p => p.Invoice)
+                .HasForeignKey(p => p.InvoiceId);
+            modelBuilder.Entity<Invoice>()
+                .HasMany(b => b.Journals)
+                .WithRequired(p => p.Invoice)
+                .HasForeignKey(p => p.InvoiceId);
+
+            modelBuilder.Entity<BatchInvoice>()
+                .ToTable("BatchInvoice")
+                .HasKey(p => p.Id);
+            modelBuilder.Entity<BatchInvoice>()
+                .Property(p => p.Id)
+                .HasColumnName("PrimaryKey");
+            modelBuilder.Entity<BatchInvoice>()
+                .HasMany(p => p.Invoices)
+                .WithRequired(k => k.BatchInvoice)
+                .HasForeignKey(k => k.BatchInvoiceId);
+
+            modelBuilder.Entity<Journal>()
+                .ToTable("Journal")
+                .HasKey(p => p.Id);
+            modelBuilder.Entity<Journal>()
+                .Property(p => p.Id)
+                .HasColumnName("PrimaryKey");
+            modelBuilder.Entity<Journal>()
+                .HasMany(p => p.Invoices)
+                .WithRequired(k => k.Journal)
+                .HasForeignKey(k => k.JournalId);
+        }
+    }
+}

--- a/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6.Tests/Tests/BulkOperationTestBase.cs
+++ b/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6.Tests/Tests/BulkOperationTestBase.cs
@@ -27,6 +27,26 @@ namespace Tanneryd.BulkOperations.EF6.Tests.Tests
     public class BulkOperationTestBase
 
     {
+        #region Invoice
+
+        protected void InitializeInvoiceContext()
+        {
+            Database.SetInitializer(new DropCreateDatabaseAlways<InvoiceContext>());
+        }
+
+        protected void CleanupInvoiceContext()
+        {
+            var db = new InvoiceContext();
+            db.BatchInvoiceItems.RemoveRange(db.BatchInvoiceItems.ToArray());
+            db.InvoiceItems.RemoveRange(db.InvoiceItems.ToArray());
+            db.Invoices.RemoveRange(db.Invoices.ToArray());
+            db.Journals.RemoveRange(db.Journals.ToArray());
+            db.BatchInvoices.RemoveRange(db.BatchInvoices.ToArray());
+            db.SaveChanges();
+        }
+
+        #endregion
+
         #region Teams
 
         protected void InitializeTeamContext()

--- a/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6.Tests/Tests/Insert/BulkInsertInvoice.cs
+++ b/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6.Tests/Tests/Insert/BulkInsertInvoice.cs
@@ -1,0 +1,81 @@
+﻿/*
+* Copyright ©  2017-2019 Tånneryd IT AB
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* 
+*   http://www.apache.org/licenses/LICENSE-2.0
+* 
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Tanneryd.BulkOperations.EF6.NetStd;
+using Tanneryd.BulkOperations.EF6.NetStd.Model;
+using Tanneryd.BulkOperations.EF6.Tests.DM.Invoice;
+using Tanneryd.BulkOperations.EF6.Tests.EF;
+
+namespace Tanneryd.BulkOperations.EF6.Tests.Tests.Insert
+{
+    [TestClass]
+    public class BulkInsertInvoice : BulkOperationTestBase
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            InitializeInvoiceContext();
+            CleanUp(); // make sure we start from scratch, previous tests might have been aborted before cleanup
+
+        }
+
+        [TestCleanup]
+        public void CleanUp()
+        {
+            CleanupInvoiceContext();
+        }
+
+        [TestMethod]
+        public void InsertBatchInvoiceWithInvoiceForEachExistingJournal()
+        {
+            using (var db = new InvoiceContext())
+            {
+                for(int i = 0; i < 10; i++)
+                {
+                    db.Journals.Add(new Journal() { Id = Guid.NewGuid() });
+                }
+                db.SaveChanges();
+
+                var batchInvoice = new BatchInvoice { Id = Guid.NewGuid() };
+
+                foreach(var journal in db.Journals.ToList())
+                {
+                    var invoice = new Invoice() { Id = Guid.NewGuid() };
+                    invoice.Journals.Add(new InvoiceItem() { JournalId = journal.Id });
+                    batchInvoice.Invoices.Add(new BatchInvoiceItem() { Id = Guid.NewGuid(), Invoice = invoice });
+                }
+
+                var req = new BulkInsertRequest<BatchInvoice>
+                {
+                    Entities = new[] { batchInvoice }.ToList(),
+                    AllowNotNullSelfReferences = AllowNotNullSelfReferences.No,
+                    SortUsingClusteredIndex = true,
+                    EnableRecursiveInsert = EnableRecursiveInsert.Yes
+                };
+                var response = db.BulkInsertAll(req);
+
+                Assert.AreEqual(1, db.BatchInvoices.ToArray().Count());
+                Assert.AreEqual(10, db.BatchInvoiceItems.ToArray().Count());
+                Assert.AreEqual(10, db.Invoices.ToArray().Count());
+                Assert.AreEqual(10, db.InvoiceItems.ToArray().Count());
+            }
+        }       
+    }
+}

--- a/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6/DbContextExtensions.cs
+++ b/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6/DbContextExtensions.cs
@@ -487,7 +487,7 @@ namespace Tanneryd.BulkOperations.EF6.NetStd
             }
 
             var keyMappings = columnMappings.Values
-                .Where(m => request.KeyPropertyMappings.Any(kpm => kpm.EntityPropertyName == m.TableColumn.Name))
+                .Where(m => request.KeyPropertyMappings.Any(kpm => kpm.EntityPropertyName == m.EntityProperty.Name))
                 .ToDictionary(m => m.EntityProperty.Name, m => m);
 
             if (keyMappings.Any())


### PR DESCRIPTION
I am currently optimizing a batch operation, which currently has, thanks to EF, a high number of queries against the database. Your library has already helped to reduce the `UPDATE` queries, but it failed after I tried to replace the `INSERT` queries with `BulkInsertAll`. I debugged your code and came to the conclusion, that the problem has to be the different names of the primary key in the database respectively the EF model and the use of `BulkSelectNotExisting`. Therefore, I guess it is a consequential error of #23.

The fix itself is quite simple, if I understand your code correctly. Additionally, I added a new context, which represents a simplistic view on my DB model, and added a corresponding test case to each of `BulkInsertAll` and `BulkSelectNotExisting`.

Hope this is helpful. 
