### PR TITLE
Update DbContextExtensions.cs

### DIFF
--- a/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6/DbContextExtensions.cs
+++ b/Tanneryd.BulkOperations.EF6/Tanneryd.BulkOperations.EF6/DbContextExtensions.cs
@@ -430,7 +430,7 @@ namespace Tanneryd.BulkOperations.EF6
                 DestinationTableName = tableName,
                 EnableStreaming = true,
                 BatchSize = 1000000,
-                BulkCopyTimeout = 10 * 60
+                BulkCopyTimeout = 0
             };
 
             foreach (var property in properties)


### PR DESCRIPTION
When using a schedule to execute a large amount of data, a timeout occurs